### PR TITLE
readme: Replace gem install with bundle install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Source code repo for the pelux.io website
 
 This website uses [jekyll](https://jekyllrb.com/) to build static HTML. Those are the steps to build it:
 
-    gem install jekyll bundler
-    # git clone <path to git> pelux.io
+    git clone <git repo url>
     cd pelux.io
+    bundle install
     bundle exec jekyll serve
     
 This will compile the markdown code and start a server at [http://localhost:4000/](http://localhost:4000/) which you can then open in your browser.


### PR DESCRIPTION
In the README the how to build instructions tell the user to use
gem install, but they should use bundle install instead, so they
would get the right versions of the gems according to the Gemfile.