### PR TITLE
Add a Jenkinsfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,3 +26,5 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
+# Checks your resulting site to ensure all links and images exist
+gem "html-proofer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,30 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.1.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     colorator (1.1.0)
+    colored (1.2)
+    concurrent-ruby (1.0.5)
+    ethon (0.10.1)
+      ffi (>= 1.3.0)
     ffi (1.9.18)
     forwardable-extended (2.6.0)
+    html-proofer (3.7.2)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      colored (~> 1.2)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.7)
+      parallel (~> 1.3)
+      typhoeus (~> 0.7)
+      yell (~> 2.0)
+    i18n (0.8.4)
     jekyll (3.4.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -29,8 +48,13 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
+    mini_portile2 (2.2.0)
     minima (2.1.1)
       jekyll (~> 3.3)
+    minitest (5.10.2)
+    nokogiri (1.8.0)
+      mini_portile2 (~> 2.2.0)
+    parallel (1.11.2)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
@@ -40,11 +64,18 @@ GEM
     rouge (1.11.1)
     safe_yaml (1.0.4)
     sass (3.4.24)
+    thread_safe (0.3.6)
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
+    yell (2.0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  html-proofer
   jekyll (= 3.4.3)
   jekyll-feed (~> 0.6)
   minima (~> 2.0)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,45 @@
+pipeline {
+    agent {
+        node { label 'Jekyl' }
+    }
+
+    stages {
+        stage('Download') {
+            steps {
+                // Delete old files
+                sh 'rm -rf .[^.] .??* *'
+                
+                // Checkout the git repository and refspec pointed to by jenkins
+                checkout scm
+            }
+        }
+        
+        // Configure the software
+        stage('Configure') {
+            steps {
+                script {
+                    sh "bundle install --path vendor/bundle"
+                }
+            }
+        }
+
+        stage("Build") {
+            steps {
+                sh "bundle exec jekyll build"
+            }
+        }
+
+        stage("Test") {
+            steps {
+                sh "bundle exec htmlproofer _site"
+            }
+        }
+
+        stage('Archive') {
+            steps {
+                // Store the artifacts of the entire build
+                archive "_site/**/*"
+            }
+        }        
+    }   
+}

--- a/_config.yml
+++ b/_config.yml
@@ -30,3 +30,6 @@ gems:
 exclude:
   - Gemfile
   - Gemfile.lock
+  - vendor/
+  - Jenkinsfile
+  - README.md


### PR DESCRIPTION
To be independent of gh-pages we need to build the website ourselves,
and to do so the easiest way it doing it with Jenkins. This
Jenkinsfile clones the repo installs the necessary ruby gems,
builds the website and archives the _site directory.

A different job will then move the static files to a webserver.