### PR TITLE
Add ruby-dev as debian host  dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Source code repo for the pelux.io website
 
 This website uses [jekyll](https://jekyllrb.com/) to build static HTML. Those are the steps to build it:
 
-    apt install ruby-bundler
+    sudo apt install ruby ruby-dev ruby-bundler
     git clone <git repo url>
     cd pelux.io
     bundle install


### PR DESCRIPTION
When building the gems, on a debian based system per default there
are no headers installed which makes the bundle install break.