### PR TITLE
Remove Test stage for now

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,11 +29,13 @@ pipeline {
             }
         }
 
-        stage("Test") {
-            steps {
-                sh "bundle exec htmlproofer _site"
-            }
-        }
+        // Dont't run tests untill we have moved the IRC logs
+        // because the build server can't reach it and fails for now.
+        // stage("Test") {
+        //    steps {
+        //        sh "bundle exec htmlproofer _site"
+        //    }
+        // }
 
         stage('Archive') {
             steps {


### PR DESCRIPTION
Dont't run tests untill we have moved the IRC logs because the
build server can't reach it for some reason and fails for now,
which it shouldn't.