### PR TITLE
Remove the (R) symbol from the webpage's title

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@
 # you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-title: PELUX®
+title: PELUX
 email: info@pelagicore.com
 description: PELUX is a Linux based platform for for IVI systems.
 repo: <a href="https://github.com/pelagicore/pelux.io">Source</a> of this website


### PR DESCRIPTION
We don't own a registered trademark here, let's not claim it