### PR TITLE
roadmap.md: Remove SDL from the roadmap

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -31,4 +31,3 @@ The content is yet to be discussed. Tentatively the topics in focus will be:
 
 - Audio manager
 - Device manager
-- SDL integration


### PR DESCRIPTION
It was decided that the focus will not be on SDL for the upcoming
releases.

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>