### PR TITLE
demo.md: Update to a newer and working video of ARP+Pelux at CES

### DIFF
--- a/demo.md
+++ b/demo.md
@@ -4,7 +4,8 @@ title: Demo
 permalink: /demo/
 ---
 
-A short demo in which Joakim, one of the developers, presents the PELUX platform
-with [Qt Automotive Suite](https://www.qt.io/qt-automotive-suite/) on top of it.
+A short video of PELUX running with [Qt Automotive Suite](https://www.qt.io/qt-automotive-suite/)
+ on the [Automotive Reference Platform (ARP)](https://www.luxoft.com/pr/luxoft-and-intel-collaborate-to-create-fully-integrated-digital-cockpit-computer-reference-platform/)
+as of January 2018.
 
-<iframe width="640" height="360" src="https://www.youtube.com/embed/rD0HN74U1mM" frameborder="0" allowfullscreen></iframe>
+<iframe width="640" height="360" src="https://www.youtube.com/embed/x8SOfRLP8_M" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
As [discussed on IRC](http://pelux.io/irclogs/channels/%23PELUX/2018-01-22/), the current video on http://pelux.io/demo/ is broken. thenor proposed to replace the previous link with a newer one from CES: https://www.youtube.com/watch?v=x8SOfRLP8_M