### PR TITLE
Gemfile: update nokogiri version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,4 +27,4 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 # Checks your resulting site to ensure all links and images exist
-gem "html-proofer"
+gem "html-proofer", "~>3.8.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.2)
+    activesupport (5.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -9,22 +9,23 @@ GEM
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     colorator (1.1.0)
-    colored (1.2)
+    colorize (0.8.1)
     concurrent-ruby (1.0.5)
-    ethon (0.10.1)
+    ethon (0.11.0)
       ffi (>= 1.3.0)
     ffi (1.9.18)
     forwardable-extended (2.6.0)
-    html-proofer (3.7.2)
+    html-proofer (3.8.0)
       activesupport (>= 4.2, < 6.0)
       addressable (~> 2.3)
-      colored (~> 1.2)
+      colorize (~> 0.8)
       mercenary (~> 0.3.2)
-      nokogiri (~> 1.7)
+      nokogiri (~> 1.8.1)
       parallel (~> 1.3)
-      typhoeus (~> 0.7)
+      typhoeus (~> 1.3)
       yell (~> 2.0)
-    i18n (0.8.4)
+    i18n (0.9.3)
+      concurrent-ruby (~> 1.0)
     jekyll (3.4.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -48,13 +49,13 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minima (2.1.1)
       jekyll (~> 3.3)
-    minitest (5.10.2)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
-    parallel (1.11.2)
+    minitest (5.11.3)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
+    parallel (1.12.1)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
@@ -65,9 +66,9 @@ GEM
     safe_yaml (1.0.4)
     sass (3.4.24)
     thread_safe (0.3.6)
-    typhoeus (0.8.0)
-      ethon (>= 0.8.0)
-    tzinfo (1.2.3)
+    typhoeus (1.3.0)
+      ethon (>= 0.9.0)
+    tzinfo (1.2.4)
       thread_safe (~> 0.1)
     yell (2.0.7)
 
@@ -75,14 +76,14 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  html-proofer
+  html-proofer (~> 3.8.0)
   jekyll (= 3.4.3)
   jekyll-feed (~> 0.6)
   minima (~> 2.0)
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.4.1p111
+   ruby 2.3.3p222
 
 BUNDLED WITH
    1.15.1


### PR DESCRIPTION
Due to a vulnerability in libxml2 the nokogiri version needs to be updated.

Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>