### PR TITLE
Build the site in a Docker container instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:17.10
+
+RUN apt-get update && apt-get install -y \
+    git \
+    gcc \
+    make \
+    ruby \
+    ruby-dev \
+    locales \
+    ruby-bundler \
+    zlib1g-dev \
+    curl
+
+RUN rm -rf /var/lib/apt/lists/*
+
+# Add support for UTF-8.
+RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG en_US.utf8

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,9 @@
 pipeline {
     agent {
-        node { label 'Jekyll' }
+        dockerfile {
+            /* There are resolution issues on the Jenkins server for pelux.io */
+            args "--add-host=pelux.io:${env.JENKINS_IP}"
+        }
     }
 
     stages {

--- a/_config.yml
+++ b/_config.yml
@@ -34,4 +34,5 @@ exclude:
   - Gemfile.lock
   - vendor/
   - Jenkinsfile
+  - Dockerfile
   - README.md


### PR DESCRIPTION
This way, we don't need to worry about dependencies other than Docker on
our build servers, and the Dockerfile shows clearly what the
dependencies are in case someone wonders.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>