### PR TITLE
config: Fix spelling and copyright

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,8 +15,8 @@
 # in the templates via {{ site.myvariable }}.
 title: PELUX
 email: contact@pelux.io
-description: PELUX is a Linux based platform for for IVI systems.
-copyright: Copyright &copy; Pelagicore AB 2017-2018
+description: PELUX is a Linux-based platform for IVI systems
+copyright: Copyright &copy; Luxoft Sweden AB 2018
 license: Licensed under <a href="http://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA 4.0</a>
 repo: <a href="https://github.com/pelagicore/pelux.io">Source</a> of this website
 baseurl: "" # the subpath of your site, e.g. /blog


### PR DESCRIPTION
* Fixed spelling
* Changed copyright to Luxoft Sweden AB

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>