### PR TITLE
Adaptation for 'new Jenkins' and bug fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.4)
+    activesupport (5.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.5.1)
@@ -15,16 +15,16 @@ GEM
       ffi (>= 1.3.0)
     ffi (1.9.18)
     forwardable-extended (2.6.0)
-    html-proofer (3.9.0)
+    html-proofer (3.8.0)
       activesupport (>= 4.2, < 6.0)
       addressable (~> 2.3)
       colorize (~> 0.8)
       mercenary (~> 0.3.2)
-      nokogiri (~> 1.8.3)
+      nokogiri (~> 1.8.1)
       parallel (~> 1.3)
       typhoeus (~> 1.3)
       yell (~> 2.0)
-    i18n (0.9.3)
+    i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     jekyll (3.4.3)
       addressable (~> 2.4)
@@ -53,7 +53,7 @@ GEM
     minima (2.1.1)
       jekyll (~> 3.3)
     minitest (5.11.3)
-    nokogiri (1.8.3)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
     pathutil (0.14.0)
@@ -68,7 +68,7 @@ GEM
     thread_safe (0.3.6)
     typhoeus (1.3.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     yell (2.0.7)
 
@@ -76,14 +76,14 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  html-proofer (~> 3.9.0)
+  html-proofer (~> 3.8.0)
   jekyll (= 3.4.3)
   jekyll-feed (~> 0.6)
   minima (~> 2.0)
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.5.1p57
 
 BUNDLED WITH
-   1.15.1
+   1.16.4

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
 
         stage("Test") {
            steps {
-               sh "bundle exec htmlproofer _site"
+               sh "bundle exec htmlproofer --url-ignore \"/pelux.io/downloads/\" _site"
            }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,8 @@ pipeline {
     agent {
         dockerfile {
             /* There are resolution issues on the Jenkins server for pelux.io */
-            args "--add-host=pelux.io:${env.JENKINS_IP}"
+            // This is IP is hardcoded until the domain is updated to "New Jenkins"
+            args "--add-host=pelux.io:185.89.242.33"
         }
     }
 

--- a/downloads-v1.0.md
+++ b/downloads-v1.0.md
@@ -1,11 +1,11 @@
 ---
 layout: page
-title: Downloads
+title: Old releases
 permalink: /downloads/v1.0/
 ---
 
 ## PELUX 1.0
-As of 2018-01-12, PELUX 1.0 has been released! The docs can be found
+PELUX 1.0 was released on 2018-01-12. The docs can be found
 [here](//pelux.io/software-factory/v1.0/).
 
 ### Main features


### PR DESCRIPTION
Change IP for Jenkins, so new Jenkins can build.
Change the title of v1.0 download page, so we don't have duplicates.
Update gem versions.