### PR TITLE
Use branch names instead of tags for swf links

### DIFF
--- a/_download/v1.0.md
+++ b/_download/v1.0.md
@@ -6,7 +6,7 @@ permalink: /downloads/v1.0/
 
 ## PELUX 1.0
 PELUX 1.0 was released on 2018-01-12. The docs can be found
-[here](//pelux.io/software-factory/v1.0/).
+[here](//pelux.io/software-factory/PELUX-1.0/).
 
 ### Main features
  - Derived from poky
@@ -43,7 +43,7 @@ This is the initial release of PELUX.
 * The version of [PELUX Software Development
   Environment](https://github.com/Pelagicore/pelux-sde/tree/v1.0) as pointed out
   below.
-* The version of [PELUX Software Factory Baseline](//pelux.io/software-factory/v1.0/) as
+* The version of [PELUX Software Factory Baseline](//pelux.io/software-factory/PELUX-1.0/) as
   pointed out below.
 
 ### Branches and tags
@@ -68,5 +68,5 @@ This is the initial release of PELUX.
 
 ## Build from source
 To build PELUX from source, read the [relevant
-chapter](//pelux.io/software-factory/master/chapters/baseplatform/index.html) in
+chapter](//pelux.io/software-factory/PELUX-1.0/chapters/baseplatform/index.html) in
 the Software Factory.

--- a/download.md
+++ b/download.md
@@ -6,7 +6,7 @@ permalink: /downloads/
 
 ## PELUX 2.0
 As of 2018-07-02, PELUX 2.0 has been released! The docs can be found
-[here](//pelux.io/software-factory/v2.0/).
+[here](//pelux.io/software-factory/PELUX-2.0/).
 
 ### Main features
  - Derived from poky
@@ -47,7 +47,7 @@ As of 2018-07-02, PELUX 2.0 has been released! The docs can be found
 * The version of [PELUX Software Development
   Environment](https://github.com/Pelagicore/pelux-sde/tree/v2.0) as pointed out
   below.
-* The version of [PELUX Software Factory Baseline](//pelux.io/software-factory/v2.0/) as
+* The version of [PELUX Software Factory Baseline](//pelux.io/software-factory/PELUX-2.0/) as
   pointed out below.
 
 ### Branches and tags
@@ -76,5 +76,5 @@ As of 2018-07-02, PELUX 2.0 has been released! The docs can be found
 
 ## Build from source
 To build PELUX from source, read the [relevant
-chapter](//pelux.io/software-factory/master/chapters/baseplatform/index.html) in
+chapter](//pelux.io/software-factory/PELUX-2.0/chapters/baseplatform/index.html) in
 the Software Factory.


### PR DESCRIPTION
The links on the website point to the swf tag builds and will be
changed to point to the release branch instead, since the tags are
linked to a specific commit and any bug fixes or other necessary updates
on the release branches won't take effect or be visible.

Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>