### PR TITLE
roadmap.md: Removed PELUX 3.0

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -20,9 +20,3 @@ The PELUX project aims to provide biannual releases. The first release was done
 in January 2018. For already released versions, see the [downloads](/downloads)
 page.
 
-### PELUX 3.0 [November 2018]
-Content of this release is under discussion. Tentatively the topics in focus will be:
-- Adaptation to Yocto "sumo" 2.5
-- Neptune UI 3
-- Qt 5.11
-- Various fixes


### PR DESCRIPTION
Version 3.0 has been released so not part of the roadmap.