### PR TITLE
htmlproofer fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
 
         stage("Test") {
             steps {
-                sh "bundle exec htmlproofer _site"
+                sh "bundle exec htmlproofer --disable-external ./_site"
             }
         }
 

--- a/_posts/2018-01-12-PELUX-1.0.md
+++ b/_posts/2018-01-12-PELUX-1.0.md
@@ -30,5 +30,5 @@ platform that changes how your automotive software is created: by
 relying on advanced technical solutions, leveraging open source
 projects and defining a scaled agile way of working.
 
-Read more about the release details on the [downloads](/downloads)
+Read more about the release details on the [releases](/releases)
 page!

--- a/_posts/2018-07-02-PELUX-2.0.md
+++ b/_posts/2018-07-02-PELUX-2.0.md
@@ -16,5 +16,5 @@ This major release contains the following changes:
 - ACPI support for Intel NUC
 - Improved documentation
 
-Read more about the release details on the [downloads](/downloads)
+Read more about the release details on the [releases](/releases)
 page!

--- a/_posts/2018-11-19-PELUX-3.0.md
+++ b/_posts/2018-11-19-PELUX-3.0.md
@@ -16,5 +16,5 @@ This major release contains the following changes:
 - Improved architectural documentation
 - Various fixes
 
-Read more about the release details on the [downloads](/downloads)
+Read more about the release details on the [releases](/releases)
 page!


### PR DESCRIPTION
htmlproofer found a couple of broken links from blogposts due to the renaming of downloads to releases, and these links have been fixed.
The webserver needs to be fixed regarding the /irclogs link and until this has been fixed, the check for external links have been disabled. Another problem with that fix is that all external link checks fails when executed by Jenkins using docker.