### PR TITLE
releases: rename download collection to release

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,5 +22,5 @@ exclude:
   - Dockerfile
   - README.md
 collections:
-  download:
+  release:
     output: true

--- a/_release/v1.0.md
+++ b/_release/v1.0.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: PELUX 1.0 (not maintained)
-permalink: /downloads/v1.0/
+permalink: /releases/v1.0/
 ---
 
 ## PELUX 1.0

--- a/_release/v2.0.md
+++ b/_release/v2.0.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: PELUX 2.0 (not maintained)
-permalink: /downloads/v2.0/
+permalink: /releases/v2.0/
 ---
 
 ## PELUX 2.0

--- a/releases.md
+++ b/releases.md
@@ -100,8 +100,8 @@ As of 2018-11-16, PELUX 3.0 has been released! Documentation can be found
 ------------------------
 
 ## Older releases
-{% for download in site.download %}
-  - <a href="{{ download.url }}">{{ download.title }}</a>
+{% for release in site.release %}
+  - <a href="{{ release.url }}">{{ release.title }}</a>
 {% endfor %}
 
 ## Build from source


### PR DESCRIPTION
Renamed collection used to store info about releases for consitency
as the main page has been renamed from downloads to releases.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>